### PR TITLE
Update Railway Cli from 2.1.0 to 3.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.1.1
+
+* Update @railway/cli from 2.1.0 to 3.0.13
+
 ## 0.1.0
 
 ### Breaking Changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:19-alpine
 
 # Install Railway CLI
-RUN npm i -g @railway/cli@2.1.0
+RUN npm i -g @railway/cli@3.0.13
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Hello 👋 

Updating the CLI to use the latest version of the npm package `railway/cli`

NPM package: https://www.npmjs.com/package/@railway/cli
CLI change: from [v2 to v3](https://docs.railway.app/develop/cli#cli-v3-changes)