### PR TITLE
Bugfix with the version 3 of Railway CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.2
 
 * Update the Dockerfile to install @railway/cli with their bash install script.
+* Update Github action output
 * Update @railway/cli from 3.0.13 to 3.0.19
 
 ## 0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.1.2
+
+* Update the Dockerfile to install @railway/cli with their bash install script.
+* Update @railway/cli from 3.0.13 to 3.0.19
+
 ## 0.1.1
 
 * Update @railway/cli from 2.1.0 to 3.0.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update the Dockerfile to install @railway/cli with their bash install script.
 * Update Github action output
 * Update @railway/cli from 3.0.13 to 3.0.19
+* Add optional inputs for the detach mode of the railway/cli
 
 ## 0.1.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 # Container image that runs your code
 FROM node:19-alpine
 
-# Install Railway CLI
-RUN npm i -g @railway/cli@3.0.13
+# Install Railway CLI with their install script
+RUN apk add curl && apk add tar
+
+# Set the version ourself
+ENV RAILWAY_VERSION=3.0.19
+
+RUN curl -fsSL cli.new | sh
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   service: # the specific service target
     description: 'The specific service target'
     required: true
+  detach: # detatch option
+    description: 'Detach option in the railway cli option'
+    required: false
 outputs:
   status: # status output
     description: ''
@@ -16,3 +19,4 @@ runs:
   args:
     - ${{ inputs.service }}
     - ${{ inputs.railway_token }}
+    - ${{ inputs.detach }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,15 @@ if [ $2 ] ; then
   export RAILWAY_TOKEN=$2
 fi
 
-railway up --detach --service $1 || error_code=$?
+detach=""
+if [ $3 ] ; then
+  detach="--detach"
+fi
+
+error_code=0
+railwayCmd="railway up --service $1 "${detach}""
+eval $railwayCmd || error_code=$?
+
 if [ "${error_code}" -ne 0 ]; then
     exit $error_code
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,9 +5,9 @@ if [ $2 ] ; then
   export RAILWAY_TOKEN=$2
 fi
 
-railway up --service $1 || error_code=$?
+railway up --detach --service $1 || error_code=$?
 if [ "${error_code}" -ne 0 ]; then
-  exit $error_code
+    exit $error_code
 else
-  echo "::set-output name=status::Success"
+    echo "status=Success" >> $GITHUB_OUTPUT
 fi


### PR DESCRIPTION
👋  

With version 3 of Railway CLI, which I introduce yesterday I notice an issue with the Dockerfile. 
I noticed the cli didn't install at all on alpine. 

I saw some people complaining about version 3 and their npm packages. 

So this change proposes: 

- Use Railway CLI [bash script](https://raw.githubusercontent.com/railwayapp/cli/master/install.sh) instead of npm module
- Update to the latest version available of Railway CLI ( 3.0.19 )
- Update the Github action output as `::set-output name=status::Success` is [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

Let me know your though 😄 

PS: Example of Action that I run with my fork this morning: [here](https://github.com/Vico1993/Otto/actions/runs/4560470422)